### PR TITLE
debug message fix

### DIFF
--- a/src/entities/Node.ts
+++ b/src/entities/Node.ts
@@ -279,7 +279,7 @@ export class Node {
               "Moonlink.js > Player " +
                 player.guildId +
                 " has an exception: " +
-                payload.exception,
+                JSON.stringify(payload.exception),
             );
             break;
           }


### PR DESCRIPTION
Hey I was using this library earlier and noticed this.
![image](https://github.com/user-attachments/assets/06381ed9-8ae1-42dc-a0b6-814a0bd88347)

This is a fix to it. 
 