### PR TITLE
fix : queueEnd event

### DIFF
--- a/src/entities/Node.ts
+++ b/src/entities/Node.ts
@@ -250,11 +250,16 @@ export class Node {
                   player.guildId +
                   " has been destroyed because of autoLeave.",
               );
-              return;
             }
             if (!player.queue.size) {
               player.current = null;
               player.queue.clear();
+
+              this.manager.emit(
+                "queueEnd",
+                player,
+                player.current
+              )
 
               this.manager.emit(
                 "debug",

--- a/src/typings/Interfaces.ts
+++ b/src/typings/Interfaces.ts
@@ -59,6 +59,7 @@ export interface IEvents {
   ) => void;
   trackStuck: (player: Player, track: Track, threshold: number) => void;
   trackException: (player: Player, track: Track, exception: any) => void;
+  queueEnd: (player: Player, track?: any) => void;
   socketClosed: (
     player: Player,
     code: number,


### PR DESCRIPTION
When autoLeave is set to true, it ensures that queueEnd operates properly as well.