### PR TITLE
Potential fix for code scanning alert no. 435: Incomplete URL substring sanitization

### DIFF
--- a/src/sources/Spotify.ts
+++ b/src/sources/Spotify.ts
@@ -21,12 +21,18 @@ export default class Spotify implements ISource {
   }
 
   public match(url: string): boolean {
-    return (
-      url.includes('spotify.com') ||
-      url.startsWith('spotify:') ||
-      url.startsWith('spsearch:') ||
-      url.startsWith('sprec:')
-    );
+    try {
+      const parsedUrl = new URL(url);
+      const allowedHosts = ['open.spotify.com', 'api.spotify.com'];
+      return (
+        allowedHosts.includes(parsedUrl.host) ||
+        url.startsWith('spotify:') ||
+        url.startsWith('spsearch:') ||
+        url.startsWith('sprec:')
+      );
+    } catch {
+      return false; // Return false if the URL is invalid
+    }
   }
 
   private generateTotp(): [string, number] {


### PR DESCRIPTION
Potential fix for [https://github.com/Ecliptia/moonlink.js/security/code-scanning/435](https://github.com/Ecliptia/moonlink.js/security/code-scanning/435)

To fix the issue, the `match` function should parse the URL and validate its host explicitly. Instead of checking if `'spotify.com'` is a substring of the URL, the function should use a URL parser to extract the host and compare it against a whitelist of allowed hosts. This ensures that only valid Spotify URLs are matched.

The `url` parameter should be parsed using the `URL` class, which is built into Node.js. The host of the parsed URL can then be compared against a predefined list of allowed Spotify hosts, such as `open.spotify.com` and `api.spotify.com`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
