### PR TITLE
feat(Node): add automatic track error recovery with configurable skip…

### DIFF
--- a/src/entities/Node.ts
+++ b/src/entities/Node.ts
@@ -586,22 +586,7 @@ export class Node {
             );
             
             if (this.manager.options.trackErrorHandling?.skipOnStuck) {
-              this.manager.emit(
-                "debug",
-                `Moonlink.js > Auto-skipping stuck track for player ${player.guildId}`
-              );
-              if (player.queue.size > 0) {
-                player.play();
-              } else if (player.autoPlay) {
-                const autoplayed = await this._handleAutoplay(player, "stuck");
-                if (!autoplayed) {
-                  player.current = null;
-                  this.manager.emit("queueEnd", player);
-                }
-              } else {
-                player.current = null;
-                this.manager.emit("queueEnd", player);
-              }
+              await this._handleTrackAutoSkip(player, "stuck");
             }
             break;
           }
@@ -616,22 +601,7 @@ export class Node {
             );
             
             if (this.manager.options.trackErrorHandling?.skipOnException) {
-              this.manager.emit(
-                "debug",
-                `Moonlink.js > Auto-skipping failed track for player ${player.guildId} due to exception`
-              );
-              if (player.queue.size > 0) {
-                player.play();
-              } else if (player.autoPlay) {
-                const autoplayed = await this._handleAutoplay(player, "exception");
-                if (!autoplayed) {
-                  player.current = null;
-                  this.manager.emit("queueEnd", player);
-                }
-              } else {
-                player.current = null;
-                this.manager.emit("queueEnd", player);
-              }
+              await this._handleTrackAutoSkip(player, "exception");
             }
             break;
           }
@@ -772,6 +742,24 @@ export class Node {
         `Moonlink.js > Player ${player.guildId} is autoplay failed: no random track found`
       );
       return false;
+    }
+  }
+
+  private async _handleTrackAutoSkip(player: Player, reason: string): Promise<void> {
+    this.manager.emit(
+      "debug",
+      `Moonlink.js > Auto-skipping ${reason} track for player ${player.guildId}`
+    );
+    const skipped = await player.skip();
+    if (!skipped && player.autoPlay) {
+      const autoplayed = await this._handleAutoplay(player, reason);
+      if (!autoplayed) {
+        player.current = null;
+        this.manager.emit("queueEnd", player);
+      }
+    } else if (!skipped) {
+      player.current = null;
+      this.manager.emit("queueEnd", player);
     }
   }
 

--- a/src/entities/Node.ts
+++ b/src/entities/Node.ts
@@ -584,6 +584,25 @@ export class Node {
               payload.thresholdMs +
               "ms."
             );
+            
+            if (this.manager.options.trackErrorHandling?.skipOnStuck) {
+              this.manager.emit(
+                "debug",
+                `Moonlink.js > Auto-skipping stuck track for player ${player.guildId}`
+              );
+              if (player.queue.size > 0) {
+                player.play();
+              } else if (player.autoPlay) {
+                const autoplayed = await this._handleAutoplay(player, "stuck");
+                if (!autoplayed) {
+                  player.current = null;
+                  this.manager.emit("queueEnd", player);
+                }
+              } else {
+                player.current = null;
+                this.manager.emit("queueEnd", player);
+              }
+            }
             break;
           }
           case "TrackExceptionEvent": {
@@ -595,6 +614,25 @@ export class Node {
               " has an exception: " +
               JSON.stringify(payload.exception)
             );
+            
+            if (this.manager.options.trackErrorHandling?.skipOnException) {
+              this.manager.emit(
+                "debug",
+                `Moonlink.js > Auto-skipping failed track for player ${player.guildId} due to exception`
+              );
+              if (player.queue.size > 0) {
+                player.play();
+              } else if (player.autoPlay) {
+                const autoplayed = await this._handleAutoplay(player, "exception");
+                if (!autoplayed) {
+                  player.current = null;
+                  this.manager.emit("queueEnd", player);
+                }
+              } else {
+                player.current = null;
+                this.manager.emit("queueEnd", player);
+              }
+            }
             break;
           }
           case "WebSocketClosedEvent": {

--- a/src/entities/Node.ts
+++ b/src/entities/Node.ts
@@ -7,6 +7,7 @@ import {
   decodeTrack,
   generateUUID,
   Player,
+  delay,
 } from "../../index";
 
 import WebSocket from "../services/WebSocket"
@@ -407,6 +408,7 @@ export class Node {
             player.playing = true;
             player.paused = false;
             player.current.position = payload.track.info?.position || 0;
+            player.trackErrorRetries = 0;
 
             this.manager.clearLyricsCacheForGuild(player.guildId);
 
@@ -746,10 +748,30 @@ export class Node {
   }
 
   private async _handleTrackAutoSkip(player: Player, reason: string): Promise<void> {
+    const maxRetries = this.manager.options.trackErrorHandling?.maxRetries ?? 0;
+    const retryDelayMs = this.manager.options.trackErrorHandling?.retryDelay ?? 3000;
+
+    if (maxRetries > 0 && player.trackErrorRetries < maxRetries) {
+      player.trackErrorRetries++;
+      this.manager.emit(
+        "debug",
+        `Moonlink.js > Retrying ${reason} track for player ${player.guildId} (attempt ${player.trackErrorRetries}/${maxRetries})`
+      );
+      
+      await delay(retryDelayMs);
+      
+      if (player.current) {
+        await player.restart();
+        return;
+      }
+    }
+
+    player.trackErrorRetries = 0;
     this.manager.emit(
       "debug",
-      `Moonlink.js > Auto-skipping ${reason} track for player ${player.guildId}`
+      `Moonlink.js > Auto-skipping ${reason} track for player ${player.guildId} after ${maxRetries > 0 ? maxRetries + ' retries' : 'no retries'}`
     );
+    
     const skipped = await player.skip();
     if (!skipped && player.autoPlay) {
       const autoplayed = await this._handleAutoplay(player, reason);

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -41,6 +41,7 @@ export class Player {
   public readonly filters: Filters;
   public healthCheckTimeout: NodeJS.Timeout | null = null;
   public isResuming: boolean = false;
+  public trackErrorRetries: number = 0;
 
   private _listen: Listen;
   private _lyrics: Lyrics;

--- a/src/entities/Rest.ts
+++ b/src/entities/Rest.ts
@@ -42,27 +42,58 @@ export class Rest {
     });
   }
   public async update(data: IRESTOptions): Promise<unknown> {
-    let request = await makeRequest(
-      `${this.url}/sessions/${this.node.sessionId}/players/${data.guildId}`,
-      {
-        method: "PATCH",
-        body: stringifyWithReplacer(data.data) as any,
-        headers: this.defaultHeaders,
-      }
-    );
+    const player = this.node.manager.players.get(data.guildId);
+    if (player && player.destroyed) {
+      this.node.manager.emit("debug", `Moonlink.js > Rest#update - Skipping update for destroyed player ${data.guildId}`);
+      return null;
+    }
+    
+    try {
+      let request = await makeRequest(
+        `${this.url}/sessions/${this.node.sessionId}/players/${data.guildId}`,
+        {
+          method: "PATCH",
+          body: stringifyWithReplacer(data.data) as any,
+          headers: this.defaultHeaders,
+        }
+      );
 
-    return request;
+      return request;
+    } catch (error) {
+      if (error.message?.includes('404')) {
+        this.node.manager.emit("debug", `Moonlink.js > Rest#update - Player ${data.guildId} not found on server (404). Marking as destroyed.`);
+        if (player) {
+          player.destroyed = true;
+        }
+        return null;
+      }
+      throw error;
+    }
   }
   public async destroy(guildId: string): Promise<unknown> {
-    let request = await makeRequest(
-      `${this.url}/sessions/${this.node.sessionId}/players/${guildId}`,
-      {
-        method: "DELETE",
-        headers: this.defaultHeaders,
-      }
-    );
+    const player = this.node.manager.players.get(guildId);
+    if (player && player.destroyed) {
+      this.node.manager.emit("debug", `Moonlink.js > Rest#destroy - Player ${guildId} already destroyed locally`);
+      return null;
+    }
+    
+    try {
+      let request = await makeRequest(
+        `${this.url}/sessions/${this.node.sessionId}/players/${guildId}`,
+        {
+          method: "DELETE",
+          headers: this.defaultHeaders,
+        }
+      );
 
-    return request;
+      return request;
+    } catch (error) {
+      if (error.message?.includes('404')) {
+        this.node.manager.emit("debug", `Moonlink.js > Rest#destroy - Player ${guildId} not found on server (404). Already destroyed.`);
+        return null;
+      }
+      throw error;
+    }
   }
   public getInfo(): Promise<unknown> {
     return makeRequest(`${this.url}/info`, {

--- a/src/typings/Interfaces.ts
+++ b/src/typings/Interfaces.ts
@@ -207,6 +207,12 @@ export interface IOptionsManager {
   playerHealthCheck?: {
     stalePlayerTimeout?: number;
   }
+  trackErrorHandling?: {
+    skipOnException?: boolean;
+    skipOnStuck?: boolean;
+    maxRetries?: number;
+    retryDelay?: number;
+  }
 }
 
 export interface IPlayerConfig {


### PR DESCRIPTION
## Track Error Auto-Skip

### Summary
Adds automatic track skipping when tracks fail or get stuck during playback. This prevents the player from stopping completely when a track has issues.

### What's New
Added `trackErrorHandling` option to manager configuration:
- `skipOnException` - Skip tracks that throw errors
- `skipOnStuck` - Skip tracks that freeze/hang
- `maxRetries` - For future retry logic
- `retryDelay` - For future retry logic

### How It Works
When a track fails:
1. Player detects the error (exception or stuck)
2. Automatically plays next track in queue
3. If queue is empty and autoplay is on, gets a new track
4. If nothing available, stops gracefully

### Benefits
- Music keeps playing even when tracks fail
- No manual intervention needed
- Optional feature (disabled by default)
- Works with existing code

### Example
```typescript
const manager = new Manager({
  trackErrorHandling: {
    skipOnException: true,
    skipOnStuck: true
  }
});